### PR TITLE
pass custom Elasticsearch node parameters

### DIFF
--- a/constructor.sh
+++ b/constructor.sh
@@ -316,6 +316,7 @@ node.name: ${HOSTNAME}
 discovery.zen.ping.unicast.hosts: [ $SLAVE_IPS_QUOTED ]
 discovery.zen.minimum_master_nodes: $NUM_MASTERS
 ${M_LOCK_ALL_SETTING}: true
+$(echo $ES_NODE_CONFIG | tr ' ' '\n'| sed 's/:/: /g' )
 EOF
 
 # For ES 2, we set cache preferences here

--- a/gcloud.conf
+++ b/gcloud.conf
@@ -22,6 +22,7 @@ ES_VERSION=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.goog
 PLUGIN_VERSION=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/es_plugin_version" )
 PLUGIN_DIR_VERSION=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/es_plugin_dir_version" )
 LOGSTASH_VERSION=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/es_logstash_version" )
+# key-value pairs are delimited with a whitespace, no other whitespaces should be present
 ES_NODE_CONFIG=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/es_node_config" )
 
 http_proxy=$http_proxy_save

--- a/gcloud.conf
+++ b/gcloud.conf
@@ -22,6 +22,7 @@ ES_VERSION=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.goog
 PLUGIN_VERSION=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/es_plugin_version" )
 PLUGIN_DIR_VERSION=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/es_plugin_dir_version" )
 LOGSTASH_VERSION=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/es_logstash_version" )
+ES_NODE_CONFIG=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/es_node_config" )
 
 http_proxy=$http_proxy_save
 SHOVE_BASE=1

--- a/spawner.sh
+++ b/spawner.sh
@@ -116,7 +116,7 @@ echo "Pushing metadata..."
 for slave in ${SLAVES[@]}; do
 	# The constructors should spin on es_spinlock_1 to avoid race conditions
 	gcloud compute instances add-metadata $slave \
-	--metadata es_slave_ips="${SLAVE_IPS[*]}",es_num_masters="$NUM_MASTERS",es_debug="$DEBUG",es_cluster_name="$CLUSTER_NAME",es_controller_ip="${PRIMARY_IP}",es_version="${ES_VERSION}",es_plugin_dir_version="${PLUGIN_DIR_VERSION}",es_plugin_version="${PLUGIN_VERSION}",es_logstash_version="${LOGSTASH_VERSION}",es_spinlock_1=released
+	--metadata es_slave_ips="${SLAVE_IPS[*]}",es_num_masters="$NUM_MASTERS",es_debug="$DEBUG",es_cluster_name="$CLUSTER_NAME",es_controller_ip="${PRIMARY_IP}",es_version="${ES_VERSION}",es_plugin_dir_version="${PLUGIN_DIR_VERSION}",es_plugin_version="${PLUGIN_VERSION}",es_logstash_version="${LOGSTASH_VERSION}",es_node_config="$ES_NODE_CONFIG",es_spinlock_1=released
 done
 
 echo "Waiting for OS to come up on each slave..."


### PR DESCRIPTION
This PR allows to pass extra parameters to be set in `elasticsearch.yml` via the envar `ES_NODE_CONFIG`.