### PR TITLE
[FEDE-4039] Use bundled JDK as the default for benchmark scenarios

### DIFF
--- a/constructor.sh
+++ b/constructor.sh
@@ -294,7 +294,7 @@ BASE="$BASE" \
     SERVICE_NAME="elastic" \
     CLUSTER_NAME="$CLUSTER_NAME" \
     ES_LINKNAME="$ES_LINKNAME" \
-    USE_BUNDLED_JDK="$USE_BUNDLED_JDK" \
+    USE_OTHER_JDK="$USE_OTHER_JDK" \
     ${DEMO_SCRIPT_DIR}/make-elastic.sh || exit 99
 
 

--- a/gcloud.conf
+++ b/gcloud.conf
@@ -47,8 +47,8 @@ DATA_DEVICE=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.goo
 [[ $DEBUG ]] && echo DATA_DEVICE=$DATA_DEVICE || true
 GIT_DEMOS_BRANCH=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/git_demos_branch" )
 [[ $DEBUG ]] && echo GIT_DEMOS_BRANCH=$GIT_DEMOS_BRANCH || true
-USE_BUNDLED_JDK=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/use_bundled_jdk" )
-[[ $DEBUG ]] && echo USE_BUNDLED_JDK=$USE_BUNDLED_JDK || true
+USE_OTHER_JDK=$( curl $CURL_ARGS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/use_other_jdk" )
+[[ $DEBUG ]] && echo USE_OTHER_JDK=$USE_OTHER_JDK || true
 
 http_proxy=$http_proxy_save
 SHOVE_BASE=1

--- a/spawner.sh
+++ b/spawner.sh
@@ -42,7 +42,7 @@ ES_NODE_CONFIG / --es-node-config []
 ES_DOWNLOAD_URL / --es-download-url []
 CONTROLLER_IP / --controller-ip [<primary ip of local machine>]
 CUSTOM_ES_JAVA_OPTS / --custom-es-java-opts []
-USE_BUNDLED_JDK / --use-bundled-jdk []
+USE_OTHER_JDK / --use-other-jdk []
 GIT_DEMOS_BRANCH / --git-demos-branch [master]
 SCOPES / --scopes []
 
@@ -67,7 +67,7 @@ PO_SIMPLE_PARAMS='IMAGE BOOT_DISK_TYPE BOOT_DISK_SIZE
     ES_VERSION PLUGIN_VERSION LOGSTASH_VERSION GITHUB_CREDENTIALS
     CPU_PLATFORM ES_NODE_CONFIG ES_DOWNLOAD_URL CONTROLLER_IP
     CUSTOM_ES_JAVA_OPTS SCOPES DEBUG NUM_SLAVES SLAVE_TYPE
-    USE_BUNDLED_JDK'
+    USE_OTHER_JDK'
 eval $(parse-opt-simple)
 
 # https://unix.stackexchange.com/questions/333548/how-to-prevent-word-splitting-without-preventing-empty-string-removal
@@ -218,7 +218,7 @@ es_node_config="${ES_NODE_CONFIG:-}",,,\
 es_download_url="${ES_DOWNLOAD_URL:-}",,,\
 custom_es_java_opts="${CUSTOM_ES_JAVA_OPTS:-}",,,\
 es_data_device="${DATA_DEVICE:-}",,,\
-use_bundled_jdk="${USE_BUNDLED_JDK:-}",,,\
+use_other_jdk="${USE_OTHER_JDK:-}",,,\
 git_demos_branch="${GIT_DEMOS_BRANCH:-}",,,\
 es_spinlock_1=released
 done

--- a/tests/test-gradle
+++ b/tests/test-gradle
@@ -21,7 +21,7 @@ gradleOpts=(-p benchmark -is \
     -Pfederate.commit="$FEDERATE_COMMIT" \
     -PartifactoryApiKey="$ARTIFACTORY_API_KEY" \
     -Pgcs.service.account.file="$HOME/.gcs-service-account.json" \
-    -Duse.bundled.jdk \
+    -Duse.other.jdk \
     -Dpath.gcloud.es.cluster.repo="$SCRIPT_DIR/.." \
     -Dgit.demos.branch="$DEMOS_BRANCH")
 


### PR DESCRIPTION
Fixes https://sirensolutions.atlassian.net/browse/FEDE-4039

https://github.com/sirensolutions/siren-platform/pull/4938 sets the default behaviour to using the bundled JDK. The "use bundled JDK" option is removed, and a new "use other JDK" option is added if we need to force ES to use the version defined in `JAVA_HOME`.